### PR TITLE
Allow to process images with spaces in the name

### DIFF
--- a/lib/miro/dominant_colors.rb
+++ b/lib/miro/dominant_colors.rb
@@ -118,9 +118,9 @@ module Miro
 
     def image_magick_params
       if Miro.histogram?
-        "':in[0]' -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize -alpha remove -format %c histogram:info:"
+        ":in -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize -alpha remove -format %c histogram:info:"
       else
-        "':in[0]' -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize :out"
+        ":in -resize :resolution -colors :colors -colorspace :quantize -quantize :quantize :out"
       end
     end
 


### PR DESCRIPTION
I don't know the reason, maybe some backward incompatible charges in `cocaine`, but I couldn't process images with spaces in the path without making this fix.
